### PR TITLE
fixes libusb runtime warning

### DIFF
--- a/commandline/uDMX.c
+++ b/commandline/uDMX.c
@@ -132,6 +132,7 @@ int                 nBytes;
 			printf("Starting bootloader...\nPlease use the ./uboot utility to update firmware.");						
 
 		} else {
+			usb_close(handle);
 			usage(argv[0]);
 	        exit(1);
 	    }


### PR DESCRIPTION
fixes libusb runtime warning:
libusb: warning [libusb_exit] application left some devices open